### PR TITLE
E3 complete: online play end-to-end (ws transport, online client, junction serve)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pnpm": ">=9"
   },
   "scripts": {
-    "build": "tsc -b packages/spec packages/runtime packages/renderer packages/connexon packages/mcp packages/cli && pnpm --filter @junction/renderer run bundle",
+    "build": "tsc -b packages/spec packages/runtime packages/renderer packages/connexon packages/node packages/mcp packages/cli && pnpm --filter @junction/renderer run bundle",
     "test": "pnpm -r --filter '@junction/*' test",
     "check:boundaries": "node scripts/check-boundaries.mjs",
     "check": "pnpm run check:boundaries && pnpm run build && pnpm run test",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,9 @@
     "junction": "./dist/index.js"
   },
   "main": "./dist/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -b",
     "test": "vitest run --passWithNoTests"
@@ -16,7 +18,8 @@
   "dependencies": {
     "@junction/renderer": "workspace:*",
     "@junction/runtime": "workspace:*",
-    "@junction/spec": "workspace:*"
+    "@junction/spec": "workspace:*",
+    "@junction/node": "workspace:*"
   },
   "engines": {
     "node": ">=20.19"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,12 +4,14 @@ import { formatDiagnosticText, parseGameDocument, type Diagnostic } from "@junct
 import { simulate, type SimulateReport } from "@junction/runtime";
 import { runPlay } from "./play.js";
 import { renderGameHtml } from "./render.js";
+import { startNodeServer } from "@junction/node";
 
 /**
  * junction validate <file> [--format json|text]
  * junction simulate <file> [--games N] [--seed S] [--seats N] [--max-turns M] [--format json|text]
  * junction play <file> [--seat N] [--seats N] [--seed S]
  * junction render <file> [--out file.html] [--seed S]
+ * junction serve  <file> [--port N] [--seats N] [--host H]
  * Exit codes: 0 ok, 1 diagnostics with errors / failed run, 2 usage.
  */
 
@@ -21,6 +23,8 @@ interface Flags {
   readonly seat: number;
   readonly maxTurns: number;
   readonly out?: string;
+  readonly port: number;
+  readonly host: string;
 }
 
 function parseFlags(args: readonly string[]): { positional: string[]; flags: Flags } {
@@ -32,6 +36,8 @@ function parseFlags(args: readonly string[]): { positional: string[]; flags: Fla
   let seat = 0;
   let maxTurns = 1000;
   let out: string | undefined;
+  let port = 8787;
+  let host = "127.0.0.1";
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
     const next = (): string => {
@@ -49,11 +55,13 @@ function parseFlags(args: readonly string[]): { positional: string[]; flags: Fla
     else if (arg === "--seat") seat = Number(next());
     else if (arg === "--max-turns") maxTurns = Number(next());
     else if (arg === "--out" || arg === "-o") out = next();
+    else if (arg === "--port") port = Number(next());
+    else if (arg === "--host") host = next();
     else if (arg.startsWith("--")) usage(`unknown flag ${arg}`);
     else positional.push(arg);
   }
   const resolvedFormat = format ?? (process.stdout.isTTY ? "text" : "json");
-  return { positional, flags: { format: resolvedFormat, games, seed, seats, seat, maxTurns, out } };
+  return { positional, flags: { format: resolvedFormat, games, seed, seats, seat, maxTurns, out, port, host } };
 }
 
 function usage(reason?: string): never {
@@ -65,6 +73,7 @@ function usage(reason?: string): never {
       "  junction simulate <file.yaml> [--games N] [--seed S] [--seats N] [--max-turns M] [--format json|text]",
       "  junction play     <file.yaml> [--seat N] [--seats N] [--seed S]",
       "  junction render   <file.yaml> [--out file.html] [--seed S]",
+      "  junction serve    <file.yaml> [--port N] [--seats N] [--host H]",
     ].join("\n"),
   );
   process.exit(2);
@@ -93,7 +102,7 @@ function printReport(report: SimulateReport, format: "json" | "text"): void {
 
 async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);
-  if (command !== "validate" && command !== "simulate" && command !== "play" && command !== "render") usage();
+  if (command !== "validate" && command !== "simulate" && command !== "play" && command !== "render" && command !== "serve") usage();
   const { positional, flags } = parseFlags(rest);
   const file = positional[0];
   if (file === undefined) usage("missing <file.yaml>");
@@ -128,6 +137,17 @@ async function main(): Promise<void> {
     if (flags.seat < 0 || flags.seat >= seats) usage(`--seat must be in [0, ${seats - 1}]`);
     const code = await runPlay(parsed.data, { seats, seat: flags.seat, seed: flags.seed });
     process.exit(code);
+  }
+
+  if (command === "serve") {
+    const seats = flags.seats ?? parsed.data.spec.meta.seats.min;
+    const server = await startNodeServer({ doc: parsed.data, yaml: text, seats, port: flags.port, host: flags.host });
+    console.log(`🎴  ${parsed.data.spec.meta.title} — room open`);
+    console.log(`    join code   ${server.code}`);
+    console.log(`    play url    ${server.url}`);
+    console.log(`    self-test   http://${flags.host}:${server.port}/check`);
+    console.log(`    (${seats} seats; empty seats are played by bots — Ctrl-C to close the room)`);
+    await new Promise(() => undefined); // run until interrupted
   }
 
   if (command === "render") {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src"],
-  "references": [{ "path": "../spec" }, { "path": "../runtime" }]
+  "references": [{ "path": "../spec" }, { "path": "../runtime" }, { "path": "../node" }]
 }

--- a/packages/connexon/src/core/handles.ts
+++ b/packages/connexon/src/core/handles.ts
@@ -1,0 +1,70 @@
+import { createRng, type GameEvent, type PlayerMove, type ProjectedState } from "@junction/runtime";
+
+/**
+ * Opaque wire handles. Piece ids are creation-ordered ("tile-0" is the first value),
+ * so seeing any id+identity pair lets a client decode the whole deck. On the wire,
+ * every pieceId becomes "p<n>" where n comes from a server-secret shuffle — stable for
+ * the room's lifetime (FLIP animation + targeting keys survive reconnects), but
+ * unlinkable to creation order without the seed.
+ */
+export class HandleCodec {
+  private readonly toHandle = new Map<string, string>();
+  private readonly toPiece = new Map<string, string>();
+
+  constructor(pieceIds: readonly string[], seed: string) {
+    const rng = createRng(seed);
+    const indices = pieceIds.map((_, i) => i);
+    for (let i = indices.length - 1; i > 0; i--) {
+      const j = rng.int(i + 1);
+      [indices[i], indices[j]] = [indices[j]!, indices[i]!];
+    }
+    pieceIds.forEach((id, i) => {
+      const handle = `p${indices[i]!}`;
+      this.toHandle.set(id, handle);
+      this.toPiece.set(handle, id);
+    });
+  }
+
+  toWire(pieceId: string): string {
+    return this.toHandle.get(pieceId) ?? pieceId;
+  }
+
+  fromWire(handle: string): string {
+    return this.toPiece.get(handle) ?? handle;
+  }
+
+  translateEvent(event: GameEvent): GameEvent {
+    switch (event.type) {
+      case "pieceMoved":
+      case "pieceFlipped":
+      case "propertyChanged":
+        return {
+          ...event,
+          pieceId: this.toWire(event.pieceId),
+          ...("revealed" in event && event.revealed !== undefined
+            ? { revealed: { ...event.revealed, pieceId: this.toWire(event.revealed.pieceId) } }
+            : {}),
+        };
+      default:
+        return event;
+    }
+  }
+
+  translateState(state: ProjectedState): ProjectedState {
+    return {
+      ...state,
+      zones: state.zones.map((zone) => ({
+        ...zone,
+        entries: zone.entries.map((entry) =>
+          "hidden" in entry
+            ? { ...entry, handle: this.toWire(entry.handle) }
+            : { ...entry, pieceId: this.toWire(entry.pieceId) },
+        ),
+      })),
+    };
+  }
+
+  translateMoves(moves: readonly PlayerMove[]): PlayerMove[] {
+    return moves.map((m) => (m.target === undefined ? m : { ...m, target: this.toWire(m.target) }));
+  }
+}

--- a/packages/connexon/src/core/room.ts
+++ b/packages/connexon/src/core/room.ts
@@ -12,6 +12,7 @@ import {
   type Rng,
 } from "@junction/runtime";
 import { encode } from "../protocol/messages.js";
+import { HandleCodec } from "./handles.js";
 
 /**
  * The Room — Connexon's platform-agnostic heart. It owns authoritative game state and
@@ -72,6 +73,8 @@ export class Room {
   private readonly conns = new Map<string, Conn>();
   private tokenCounter = 0;
   private botTimer: ReturnType<typeof setTimeout> | undefined;
+  /** Server-secret pieceId↔handle mapping — nothing creation-ordered crosses the wire. */
+  private readonly codec: HandleCodec;
   /** Injectable so tests can run bots synchronously. */
   private readonly schedule: (fn: () => void) => void;
 
@@ -87,6 +90,7 @@ export class Room {
     const setup = buildInitialState(this.doc, this.seatCount, createRng(`${config.hooks.seed}:setup`));
     this.state = setup.state;
     this.log.push(...setup.events);
+    this.codec = new HandleCodec(Object.keys(this.state.pieces), `${config.hooks.seed}:handles`);
     this.seats = Array.from({ length: this.seatCount }, (_, i) => ({
       connId: null,
       token: `seat${i}-${(this.tokenCounter++).toString(36)}`,
@@ -153,8 +157,9 @@ export class Room {
         game: this.doc.metadata.name,
         title: this.doc.spec.meta.title,
         spec: this.yaml,
-        state: projectState(this.state, this.doc.spec, seatIndex),
+        state: this.codec.translateState(projectState(this.state, this.doc.spec, seatIndex)),
         seq: this.lastSeq,
+        moves: this.movesFor(seatIndex),
       }),
     );
     // Resume: replay any events the client missed (lastSeq < current).
@@ -173,7 +178,8 @@ export class Room {
       this.hooks.send(connId, encode({ t: "error", code: "NOT_YOUR_TURN", message: "It is not your turn." }));
       return;
     }
-    const result = applyAction(this.state, this.doc.spec, { seat: conn.seat, action: msg.action, target: msg.target }, this.diceRng);
+    const target = msg.target === undefined ? undefined : this.codec.fromWire(msg.target);
+    const result = applyAction(this.state, this.doc.spec, { seat: conn.seat, action: msg.action, ...(target !== undefined ? { target } : {}) }, this.diceRng);
     if (!result.ok) {
       this.hooks.send(connId, encode({ t: "error", code: result.diagnostics[0]?.code ?? "ILLEGAL", message: result.diagnostics[0]?.message ?? "Illegal move." }));
       return;
@@ -201,11 +207,20 @@ export class Room {
       connId,
       encode({
         t: "patch",
-        events: events.map((e) => e), // v1alpha reveals are public; per-seat event filtering lands with private reveals
-        state: projectState(this.state, this.doc.spec, seat),
+        // v1alpha reveals are public, so all seats get the same (handle-translated) events;
+        // per-seat event filtering lands with private reveals.
+        events: events.map((e) => this.codec.translateEvent(e)),
+        state: this.codec.translateState(projectState(this.state, this.doc.spec, seat)),
         seq: this.lastSeq,
+        moves: this.movesFor(seat),
       }),
     );
+  }
+
+  /** Server-sent options: this seat's legal moves right now (handle-translated). */
+  private movesFor(seat: number): readonly import("@junction/runtime").PlayerMove[] {
+    if (this.state.status !== "running" || this.state.activeSeat !== seat) return [];
+    return this.codec.translateMoves(legalMoves(this.state, this.doc.spec));
   }
 
   private broadcastRoomInfo(): void {

--- a/packages/connexon/src/index.ts
+++ b/packages/connexon/src/index.ts
@@ -1,6 +1,7 @@
 // @junction/connexon — the online runtime: platform-agnostic room core + protocol.
 // Transport adapters (Durable Objects, Node ws) wrap the Room; nothing here imports a platform.
 export { Room, type RoomConfig, type RoomHooks } from "./core/room.js";
+export { HandleCodec } from "./core/handles.js";
 export { RoomManager, type ManagerHooks, type OpenRoomInput } from "./core/room-manager.js";
 export { autoNickname, isValidJoinCode, makeJoinCode } from "./core/join-code.js";
 export {

--- a/packages/connexon/src/protocol/messages.ts
+++ b/packages/connexon/src/protocol/messages.ts
@@ -1,4 +1,4 @@
-import type { GameEvent, ProjectedState } from "@junction/runtime";
+import type { GameEvent, PlayerMove, ProjectedState } from "@junction/runtime";
 
 /**
  * The Connexon wire protocol — plain JSON over any ordered transport (WebSocket today,
@@ -37,6 +37,8 @@ export interface WelcomeMessage {
   readonly state: ProjectedState;
   /** Highest event seq already reflected in `state`. */
   readonly seq: number;
+  /** Your legal moves right now (server-sent options — clients never know the rules). Empty unless it's your turn. */
+  readonly moves: readonly PlayerMove[];
 }
 
 /** An ordered, per-seat-projected batch of game events. */
@@ -47,6 +49,8 @@ export interface PatchMessage {
   readonly state: ProjectedState;
   /** Seq of the last event in this batch. */
   readonly seq: number;
+  /** Your legal moves after this batch (empty unless it's your turn). */
+  readonly moves: readonly PlayerMove[];
 }
 
 export interface RoomInfoMessage {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@junction/node",
+  "version": "0.0.1-alpha.0",
+  "description": "Connexon's Node adapter: a ws room server — the portability hedge and local classroom host.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@junction/connexon": "workspace:*",
+    "@junction/renderer": "workspace:*",
+    "@junction/runtime": "workspace:*",
+    "@junction/spec": "workspace:*",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.5.0"
+  },
+  "engines": { "node": ">=20.19" }
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,0 +1,2 @@
+// @junction/node — Connexon's Node ws adapter + local classroom server.
+export { startNodeServer, type RunningServer, type ServeOptions } from "./server.js";

--- a/packages/node/src/server.ts
+++ b/packages/node/src/server.ts
@@ -1,0 +1,114 @@
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { randomInt } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { WebSocketServer, type WebSocket } from "ws";
+import type { GameDocument } from "@junction/spec";
+import { RoomManager, parseClientMessage } from "@junction/connexon";
+import { buildOnlinePageHtml, computeQaBadges } from "@junction/renderer";
+
+/**
+ * The Node room server — Connexon's portability hedge (blueprint §9) and the local
+ * classroom host. One process serves: the play page (online client), `/ws?code=`
+ * websockets into rooms, and `/check` (the school-IT self-test). The same Room core
+ * will run on Durable Objects; this adapter exists so CI and a €4 VPS can run it too.
+ */
+
+export interface ServeOptions {
+  readonly doc: GameDocument;
+  readonly yaml: string;
+  readonly seats?: number;
+  readonly port?: number;
+  readonly host?: string;
+}
+
+export interface RunningServer {
+  readonly port: number;
+  readonly code: string;
+  readonly url: string;
+  readonly close: () => Promise<void>;
+}
+
+function loadBundle(): string {
+  const require = createRequire(import.meta.url);
+  return readFileSync(require.resolve("@junction/renderer/standalone.js"), "utf8");
+}
+
+export async function startNodeServer(options: ServeOptions): Promise<RunningServer> {
+  const seats = options.seats ?? options.doc.spec.meta.seats.min;
+  const host = options.host ?? "127.0.0.1";
+
+  // The play page is built once; badges simulated up front.
+  const badges = computeQaBadges(options.doc, { games: 200, seed: "serve" });
+  const page = buildOnlinePageHtml({ title: options.doc.spec.meta.title, badges, bundleJs: loadBundle() });
+
+  let connCounter = 0;
+  const sockets = new Map<string, WebSocket>();
+  const manager = new RoomManager({
+    send: (connId, text) => {
+      const ws = sockets.get(connId);
+      if (ws !== undefined && ws.readyState === ws.OPEN) ws.send(text);
+    },
+    now: () => Date.now(),
+    randomInt: (max) => randomInt(max),
+  });
+  const code = manager.open({ doc: options.doc, yaml: options.yaml, seatCount: seats });
+
+  const http: Server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://local");
+    if (url.pathname === "/" || url.pathname === "/play") {
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      res.end(page);
+      return;
+    }
+    if (url.pathname === "/check") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, websocket: "/ws", rooms: manager.openRoomCount }));
+      return;
+    }
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+  http.on("upgrade", (req: IncomingMessage, socket, head) => {
+    const url = new URL(req.url ?? "/", "http://local");
+    if (url.pathname !== "/ws") {
+      socket.destroy();
+      return;
+    }
+    const roomCode = (url.searchParams.get("code") ?? "").toUpperCase();
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      const connId = `c${connCounter++}`;
+      if (!manager.connect(roomCode, connId)) {
+        ws.send(JSON.stringify({ t: "error", code: "ROOM_NOT_FOUND", message: `No room '${roomCode}'.` }));
+        ws.close();
+        return;
+      }
+      sockets.set(connId, ws);
+      ws.on("message", (data) => {
+        const message = parseClientMessage(String(data));
+        if (message !== null) manager.handle(connId, message as unknown as { t: string; [k: string]: unknown });
+      });
+      ws.on("close", () => {
+        sockets.delete(connId);
+        manager.disconnect(connId);
+      });
+    });
+  });
+
+  await new Promise<void>((resolve) => http.listen(options.port ?? 0, host, resolve));
+  const address = http.address();
+  const port = typeof address === "object" && address !== null ? address.port : (options.port ?? 0);
+
+  return {
+    port,
+    code,
+    url: `http://${host}:${port}/?code=${code}`,
+    close: async () => {
+      manager.close(code);
+      wss.close();
+      await new Promise<void>((resolve) => http.close(() => resolve()));
+    },
+  };
+}

--- a/packages/node/test/online.test.ts
+++ b/packages/node/test/online.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import WebSocket from "ws";
+import { parseGameDocument, type GameDocument } from "@junction/spec";
+import { afterAll, describe, expect, it } from "vitest";
+import { startNodeServer, type RunningServer } from "../src/index.js";
+
+/**
+ * The E3 acceptance test: two REAL WebSocket clients play a full game of War through
+ * the authoritative server — seat assignment, server-sent options, handle-translated
+ * hidden information, ordered seqs, and a clean ending on both sides.
+ */
+
+function loadWar(): { doc: GameDocument; yaml: string } {
+  const yaml = readFileSync(fileURLToPath(new URL("../../../games/war.yaml", import.meta.url)), "utf8");
+  const parsed = parseGameDocument(yaml);
+  if (!parsed.ok) throw new Error("war invalid");
+  return { doc: parsed.data, yaml };
+}
+
+interface Frame {
+  t: string;
+  [k: string]: unknown;
+}
+
+/** A tiny test client: buffers frames, lets us await the next one matching a predicate. */
+function client(url: string): {
+  send: (m: unknown) => void;
+  next: (match: (f: Frame) => boolean, timeoutMs?: number) => Promise<Frame>;
+  frames: Frame[];
+  close: () => void;
+} {
+  const ws = new WebSocket(url);
+  const frames: Frame[] = [];
+  const waiters: { match: (f: Frame) => boolean; resolve: (f: Frame) => void }[] = [];
+  ws.on("message", (data) => {
+    const frame = JSON.parse(String(data)) as Frame;
+    frames.push(frame);
+    const index = waiters.findIndex((w) => w.match(frame));
+    if (index !== -1) waiters.splice(index, 1)[0]!.resolve(frame);
+  });
+  return {
+    frames,
+    send: (m) => {
+      const payload = JSON.stringify(m);
+      if (ws.readyState === WebSocket.OPEN) ws.send(payload);
+      else ws.on("open", () => ws.send(payload));
+    },
+    next: (match, timeoutMs = 4000) =>
+      new Promise<Frame>((resolve, reject) => {
+        const existing = frames.find(match);
+        if (existing !== undefined) {
+          resolve(existing);
+          return;
+        }
+        const timer = setTimeout(() => reject(new Error("timed out waiting for frame")), timeoutMs);
+        waiters.push({
+          match,
+          resolve: (f) => {
+            clearTimeout(timer);
+            resolve(f);
+          },
+        });
+      }),
+    close: () => ws.close(),
+  };
+}
+
+let server: RunningServer | undefined;
+afterAll(async () => {
+  await server?.close();
+});
+
+describe("two browsers, one authoritative room (E3 end-to-end)", () => {
+  it("plays a full game of War over real websockets", async () => {
+    const { doc, yaml } = loadWar();
+    server = await startNodeServer({ doc, yaml, seats: 2, port: 0 });
+    expect(server.code).toMatch(/^[2-9A-HJ-NP-Z]{5}$/);
+
+    const wsUrl = `ws://127.0.0.1:${server.port}/ws?code=${server.code}`;
+    const alice = client(wsUrl);
+    const bob = client(wsUrl);
+    alice.send({ t: "join", name: "Alice" });
+    const aWelcome = await alice.next((f) => f.t === "welcome");
+    bob.send({ t: "join", name: "Bob" });
+    const bWelcome = await bob.next((f) => f.t === "welcome");
+
+    expect(aWelcome["seat"]).toBe(0);
+    expect(bWelcome["seat"]).toBe(1);
+
+    // Hidden information is handle-translated: no creation-ordered ids on the wire.
+    const aState = aWelcome["state"] as { zones: { zone: string; ownerSeat: number | null; entries: Record<string, unknown>[] }[] };
+    const aDeck = aState.zones.find((z) => z.zone === "deck" && z.ownerSeat === 0)!;
+    expect(aDeck.entries.every((e) => "hidden" in e && /^p\d+$/.test(String(e["handle"])))).toBe(true);
+
+    // Server-sent options: it's Alice's turn; Bob has none.
+    expect((aWelcome["moves"] as unknown[]).length).toBeGreaterThan(0);
+    expect((bWelcome["moves"] as unknown[]).length).toBe(0);
+
+    // Play to the end: whoever holds moves plays them (52 plays total).
+    let aSeq = -1;
+    let bSeq = -1;
+    let ended = false;
+    for (let step = 0; step < 200 && !ended; step++) {
+      const aLast = [...alice.frames].reverse().find((f) => f.t === "welcome" || f.t === "patch");
+      const bLast = [...bob.frames].reverse().find((f) => f.t === "welcome" || f.t === "patch");
+      const aMoves = (aLast?.["moves"] ?? []) as { action: string; target?: string }[];
+      const bMoves = (bLast?.["moves"] ?? []) as { action: string; target?: string }[];
+      if (aMoves.length > 0) {
+        const seqBefore = Number(aLast!["seq"]);
+        alice.send({ t: "move", ...aMoves[0]! });
+        const patch = await alice.next((f) => f.t === "patch" && Number(f["seq"]) > seqBefore);
+        aSeq = Number(patch["seq"]);
+        ended = (patch["events"] as { type: string }[]).some((e) => e.type === "gameEnded");
+        if (!ended) await bob.next((f) => f.t === "patch" && Number(f["seq"]) >= aSeq);
+      } else if (bMoves.length > 0) {
+        const seqBefore = Number(bLast!["seq"]);
+        bob.send({ t: "move", ...bMoves[0]! });
+        const patch = await bob.next((f) => f.t === "patch" && Number(f["seq"]) > seqBefore);
+        bSeq = Number(patch["seq"]);
+        ended = (patch["events"] as { type: string }[]).some((e) => e.type === "gameEnded");
+        if (!ended) await alice.next((f) => f.t === "patch" && Number(f["seq"]) >= bSeq);
+      } else {
+        await new Promise((r) => setTimeout(r, 25));
+      }
+    }
+    expect(ended).toBe(true);
+
+    // Both clients saw the same ordered story: identical event-type sequences.
+    const story = (frames: Frame[]): string =>
+      frames
+        .filter((f) => f.t === "patch")
+        .flatMap((f) => (f["events"] as { type: string; seq: number }[]).map((e) => `${e.seq}:${e.type}`))
+        .join(",");
+    await bob.next((f) => f.t === "patch" && (f["events"] as { type: string }[]).some((e) => e.type === "gameEnded"));
+    expect(story(alice.frames)).toBe(story(bob.frames));
+
+    alice.close();
+    bob.close();
+  }, 20000);
+
+  it("serves the play page and the /check self-test", async () => {
+    const { doc, yaml } = loadWar();
+    const s = await startNodeServer({ doc, yaml, seats: 2, port: 0 });
+    const page = await (await fetch(`http://127.0.0.1:${s.port}/`)).text();
+    expect(page).toContain("JunctionGame.bootOnline()");
+    expect(page).toContain("LIVE");
+    const check = (await (await fetch(`http://127.0.0.1:${s.port}/check`)).json()) as { ok: boolean };
+    expect(check.ok).toBe(true);
+    await s.close();
+  });
+});

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../spec" },
+    { "path": "../runtime" },
+    { "path": "../connexon" },
+    { "path": "../renderer" }
+  ]
+}

--- a/packages/node/vitest.config.ts
+++ b/packages/node/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@junction/spec": fileURLToPath(new URL("../spec/src/index.ts", import.meta.url)),
+      "@junction/runtime": fileURLToPath(new URL("../runtime/src/index.ts", import.meta.url)),
+      "@junction/connexon": fileURLToPath(new URL("../connexon/src/index.ts", import.meta.url)),
+      "@junction/renderer": fileURLToPath(new URL("../renderer/src/index.ts", import.meta.url)),
+    },
+  },
+  test: { include: ["test/**/*.test.ts"], testTimeout: 20000 },
+});

--- a/packages/renderer/src/dom-renderer.ts
+++ b/packages/renderer/src/dom-renderer.ts
@@ -14,7 +14,7 @@ import { cardBackSVG, cardFaceSVG } from "./art.js";
 import { confettiBurst, scorePop } from "./celebrate.js";
 import { createSoundBank, soundForEvent, type SoundName } from "./sound.js";
 import { applyThemeTokens, celebrationColors, motionParams, resolveTheme, type MotionParams } from "./theme.js";
-import { buildViewModel, type CardVM, type ViewModel } from "./view-model.js";
+import { buildViewModel, buildViewModelFromProjection, type CardVM, type ViewModel } from "./view-model.js";
 
 /**
  * Cadherin's DOM controller: mounts a playable game into a container. Framework-free
@@ -464,4 +464,235 @@ function playFlip(host: HTMLElement, firstRects: Map<string, DOMRect>, motion: M
       { duration: motion.moveDuration, easing: motion.easing },
     );
   }
+}
+
+// ---- online play -----------------------------------------------------------------
+
+export interface OnlineMountOptions {
+  /** WebSocket URL including the room code, e.g. wss://host/ws?code=ABCDE */
+  readonly url: string;
+  readonly name?: string;
+}
+
+interface WireWelcome {
+  t: "welcome";
+  seat: number;
+  token: string;
+  title: string;
+  spec: string;
+  state: import("@junction/runtime").ProjectedState;
+  seq: number;
+  moves: { action: string; target?: string }[];
+}
+interface WirePatch {
+  t: "patch";
+  events: GameEvent[];
+  state: import("@junction/runtime").ProjectedState;
+  seq: number;
+  moves: { action: string; target?: string }[];
+}
+
+/**
+ * Mount an ONLINE game: the server is authoritative; this client renders projections
+ * and sends chosen moves. Same view-model, same juice — different state source.
+ * Reconnects with its token + lastSeq, so a dropped Chromebook resumes seamlessly.
+ */
+export function mountOnlineGame(container: HTMLElement, options: OnlineMountOptions): GameController {
+  container.innerHTML = "";
+  container.classList.add("jx-shell");
+  const status = el("p", "jx-status");
+  status.textContent = "Connecting…";
+  container.append(status);
+
+  let disposed = false;
+  let socket: WebSocket | undefined;
+  let token: string | undefined;
+  let lastSeq = -1;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Set after welcome (we need the spec to build the doc + theme).
+  let game: {
+    doc: GameDocument;
+    theme: ReturnType<typeof resolveTheme>;
+    motion: MotionParams;
+    colors: string[];
+    sound: ReturnType<typeof createSoundBank>;
+    viewerSeat: number;
+    statusEl: HTMLElement;
+    zonesHost: HTMLElement;
+    buttonsHost: HTMLElement;
+    statsHost: HTMLElement;
+    tickerHost: HTMLElement;
+    live: HTMLElement;
+    ticker: string[];
+    stepEvents: readonly GameEvent[];
+    matchStreak: number;
+    firstRender: boolean;
+  } | undefined;
+
+  function send(message: unknown): void {
+    if (socket !== undefined && socket.readyState === WebSocket.OPEN) socket.send(JSON.stringify(message));
+  }
+
+  function scaffold(welcome: WireWelcome): void {
+    const { parseGameDocument } = junctionSpec();
+    const parsed = parseGameDocument(welcome.spec, { file: "<online>" });
+    if (!parsed.ok) {
+      status.textContent = "This room's game failed to load.";
+      return;
+    }
+    const doc = parsed.data;
+    const theme = resolveTheme(doc.spec);
+    container.innerHTML = "";
+    applyThemeTokens(document.documentElement, container, theme);
+
+    const statusBar = el("div", "jx-statusbar");
+    const statusEl = el("p", "jx-status");
+    const sound = createSoundBank(theme.sound, readMuted());
+    const soundToggle = el("button", "jx-sound");
+    soundToggle.type = "button";
+    const syncToggle = (): void => {
+      const muted = sound.isMuted() || theme.sound === "off";
+      soundToggle.textContent = muted ? "🔇" : "🔊";
+      soundToggle.setAttribute("aria-label", muted ? "turn sound on" : "turn sound off");
+    };
+    soundToggle.addEventListener("click", () => {
+      sound.setMuted(!sound.isMuted());
+      storeMuted(sound.isMuted());
+      syncToggle();
+    });
+    syncToggle();
+    statusBar.append(statusEl, soundToggle);
+
+    const statsHost = el("div", "jx-stats");
+    const zonesHost = el("div", "jx-zones");
+    const buttonsHost = el("div", "jx-buttons");
+    const tickerHost = el("div", "jx-ticker");
+    const live = el("div", "visually-hidden");
+    live.setAttribute("role", "status");
+    live.setAttribute("aria-live", "polite");
+    container.append(statusBar, statsHost, zonesHost, buttonsHost, tickerHost, live);
+    container.addEventListener("pointerdown", () => sound.unlock(), { capture: true });
+
+    game = {
+      doc,
+      theme,
+      motion: motionParams(theme),
+      colors: celebrationColors(theme),
+      sound,
+      viewerSeat: welcome.seat,
+      statusEl,
+      zonesHost,
+      buttonsHost,
+      statsHost,
+      tickerHost,
+      live,
+      ticker: [],
+      stepEvents: [],
+      matchStreak: 0,
+      firstRender: true,
+    };
+  }
+
+  function renderOnline(state: import("@junction/runtime").ProjectedState, moves: { action: string; target?: string }[]): void {
+    if (game === undefined) return;
+    const g = game;
+    const vm = buildViewModelFromProjection(g.doc, state, moves);
+    const firstRects = measureCards(g.zonesHost);
+    g.statusEl.textContent = vm.statusLine;
+    g.statusEl.classList.toggle("your-turn", vm.yourTurn);
+    renderStats(g.statsHost, vm);
+    renderZones(g.zonesHost, vm, g.doc.metadata.name, (move) => {
+      g.sound.unlock();
+      send({ t: "move", ...move });
+    });
+    renderButtons(g.buttonsHost, vm, (move) => {
+      g.sound.unlock();
+      send({ t: "move", ...move });
+    });
+    renderTicker(g.tickerHost, g.ticker);
+    pulseChangedStats(g.statsHost, g.stepEvents);
+    if (g.firstRender) {
+      g.firstRender = false;
+      playEntrance(g.zonesHost, g.motion);
+    } else {
+      playFlip(g.zonesHost, firstRects, g.motion);
+    }
+    // celebrations
+    const ended = g.stepEvents.find((e) => e.type === "gameEnded");
+    if (ended?.type === "gameEnded" && ended.winnerSeat === g.viewerSeat && g.theme.celebration === "festive")
+      confettiBurst(g.colors);
+    g.stepEvents = [];
+    if (vm.ended) showBanner(container, vm);
+  }
+
+  function onMessage(raw: string): void {
+    let msg: { t?: string };
+    try {
+      msg = JSON.parse(raw) as { t?: string };
+    } catch {
+      return;
+    }
+    if (msg.t === "welcome") {
+      const welcome = msg as WireWelcome;
+      token = welcome.token;
+      lastSeq = welcome.seq;
+      scaffold(welcome);
+      renderOnline(welcome.state, welcome.moves);
+    } else if (msg.t === "patch") {
+      const patch = msg as WirePatch;
+      lastSeq = patch.seq;
+      if (game !== undefined) {
+        game.stepEvents = patch.events;
+        const lines = announceAll(patch.events, game.viewerSeat);
+        if (lines.length > 0) {
+          game.ticker = [...game.ticker, ...lines].slice(-6);
+          game.live.textContent = lines[lines.length - 1]!;
+        }
+        for (const event of patch.events)
+          if (event.type === "pairResolved" && event.bySeat === game.viewerSeat)
+            game.matchStreak = event.matched ? game.matchStreak + 1 : 0;
+        const names: SoundName[] = [];
+        for (const event of patch.events) {
+          const name = soundForEvent(event, game.viewerSeat);
+          if (name !== null && !names.includes(name)) names.push(name);
+        }
+        const finale = names.find((n) => n === "fanfare" || n === "defeat");
+        for (const name of finale !== undefined ? [finale] : names.slice(0, 2)) game.sound.play(name);
+      }
+      renderOnline(patch.state, patch.moves);
+    } else if (msg.t === "error") {
+      const err = msg as { message?: string };
+      if (game === undefined) status.textContent = err.message ?? "Room error.";
+    }
+  }
+
+  function connect(): void {
+    if (disposed) return;
+    socket = new WebSocket(options.url);
+    socket.addEventListener("open", () => {
+      send({ t: "join", ...(options.name !== undefined ? { name: options.name } : {}), ...(token !== undefined ? { token, lastSeq } : {}) });
+    });
+    socket.addEventListener("message", (event) => onMessage(String(event.data)));
+    socket.addEventListener("close", () => {
+      if (disposed) return;
+      (game?.statusEl ?? status).textContent = "Reconnecting…";
+      retryTimer = setTimeout(connect, 1200);
+    });
+  }
+  connect();
+
+  return {
+    dispose: () => {
+      disposed = true;
+      if (retryTimer !== undefined) clearTimeout(retryTimer);
+      socket?.close();
+    },
+  };
+}
+
+/** Indirection so the spec import stays at module top (bundled) without circularity. */
+import { parseGameDocument as _parseGameDocument } from "@junction/spec";
+function junctionSpec(): { parseGameDocument: typeof _parseGameDocument } {
+  return { parseGameDocument: _parseGameDocument };
 }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2,8 +2,8 @@
 export { announce, announceAll } from "./announcer.js";
 export { cardBackSVG, cardFaceSVG } from "./art.js";
 export { confettiBurst, scorePop } from "./celebrate.js";
-export { mountGame, type GameController, type MountOptions } from "./dom-renderer.js";
-export { buildGamePageHtml, computeQaBadges, type GamePageInput, type QaBadgeOptions } from "./page.js";
+export { mountGame, mountOnlineGame, type GameController, type MountOptions, type OnlineMountOptions } from "./dom-renderer.js";
+export { buildGamePageHtml, buildOnlinePageHtml, computeQaBadges, type GamePageInput, type OnlinePageInput, type QaBadgeOptions } from "./page.js";
 export { createSoundBank, soundForEvent, type SoundBank, type SoundName, type SoundSetName } from "./sound.js";
 export { CADHERIN_CSS } from "./styles.js";
 export {
@@ -16,6 +16,7 @@ export {
 } from "./theme.js";
 export {
   buildViewModel,
+  buildViewModelFromProjection,
   cardLabel,
   cardShortText,
   type CardVM,

--- a/packages/renderer/src/page.ts
+++ b/packages/renderer/src/page.ts
@@ -81,3 +81,39 @@ window.JunctionGame.boot({ yaml: ${yamlJson} });
 </html>
 `;
 }
+
+export interface OnlinePageInput {
+  readonly title: string;
+  readonly badges: readonly string[];
+  readonly bundleJs: string;
+}
+
+/** The join/play page a room server serves: same shell, boots the online client. */
+export function buildOnlinePageHtml(input: OnlinePageInput): string {
+  const badgeHtml = input.badges
+    .map((b) => `<span class="jx-badge${b.startsWith("⚠") ? " warn" : ""}">${escapeHtml(b)}</span>`)
+    .join("");
+  const bundle = input.bundleJs.replace(/<\/script/gi, "<\\/script");
+  const title = escapeHtml(input.title);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title} · Junction Live</title>
+</head>
+<body>
+<div class="jx-shell">
+  <header class="jx-header">
+    <h1 class="jx-title">${title}</h1>
+    <div class="jx-badges">${badgeHtml}<span class="jx-badge">LIVE</span></div>
+  </header>
+  <main id="junction-root" aria-label="${title} game board"></main>
+  <footer class="jx-footer">Made with Junction — playing live in an authoritative room.</footer>
+</div>
+<script>${bundle}</script>
+<script>window.JunctionGame.bootOnline();</script>
+</body>
+</html>
+`;
+}

--- a/packages/renderer/src/standalone.ts
+++ b/packages/renderer/src/standalone.ts
@@ -1,6 +1,6 @@
 import { parseGameDocument } from "@junction/spec";
 import { CADHERIN_CSS } from "./styles.js";
-import { mountGame } from "./dom-renderer.js";
+import { mountGame, mountOnlineGame } from "./dom-renderer.js";
 
 /**
  * The single-file entry: `junction render` inlines this bundle next to the GameSpec
@@ -39,10 +39,56 @@ function boot(options: BootOptions): void {
   mountGame(container, parsed.data, { seat, seats, ...(seed !== undefined ? { seed } : {}) });
 }
 
+/** Online boot: join the room whose code is in the URL (?code=ABCDE) over this host's /ws. */
+function bootOnline(options: { containerId?: string } = {}): void {
+  if (document.getElementById("jx-style") === null) {
+    const style = document.createElement("style");
+    style.id = "jx-style";
+    style.textContent = CADHERIN_CSS;
+    document.head.append(style);
+  }
+  const container = document.getElementById(options.containerId ?? "junction-root");
+  if (container === null) throw new Error("junction: container not found");
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("code") ?? "";
+  if (code === "") {
+    // The classroom join screen: type the code from the projector.
+    container.innerHTML = "";
+    const form = document.createElement("form");
+    form.className = "jx-banner-box";
+    form.style.cssText = "margin: 60px auto; max-width: 360px; display: flex; flex-direction: column; gap: 12px;";
+    const label = document.createElement("label");
+    label.textContent = "Enter your room code";
+    label.style.cssText = "font-weight: 800; font-size: 20px;";
+    const input = document.createElement("input");
+    input.style.cssText =
+      "font: inherit; font-size: 28px; font-weight: 800; text-align: center; letter-spacing: 6px; text-transform: uppercase; padding: 10px; border-radius: 10px; border: 2px solid #ccc;";
+    input.maxLength = 5;
+    input.autofocus = true;
+    input.setAttribute("aria-label", "room code");
+    const button = document.createElement("button");
+    button.type = "submit";
+    button.className = "jx-button";
+    button.textContent = "Join";
+    form.append(label, input, button);
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const value = input.value.trim().toUpperCase();
+      if (value.length === 5) window.location.search = `?code=${encodeURIComponent(value)}`;
+    });
+    container.append(form);
+    return;
+  }
+  const proto = window.location.protocol === "https:" ? "wss" : "ws";
+  const url = `${proto}://${window.location.host}/ws?code=${encodeURIComponent(code)}`;
+  const name = params.get("name") ?? undefined;
+  mountOnlineGame(container, { url, ...(name !== undefined ? { name } : {}) });
+}
+
 declare global {
   interface Window {
-    JunctionGame: { boot: (options: BootOptions) => void; css: string };
+    JunctionGame: { boot: (options: BootOptions) => void; bootOnline: (options?: { containerId?: string }) => void; css: string };
   }
 }
 
-window.JunctionGame = { boot, css: CADHERIN_CSS };
+window.JunctionGame = { boot, bootOnline, css: CADHERIN_CSS };

--- a/packages/renderer/src/view-model.ts
+++ b/packages/renderer/src/view-model.ts
@@ -1,5 +1,5 @@
 import type { GameDocument } from "@junction/spec";
-import { legalMoves, projectState, type GameState, type PlayerMove } from "@junction/runtime";
+import { legalMoves, projectState, type GameState, type PlayerMove, type ProjectedState } from "@junction/runtime";
 
 /**
  * The pure view-model: (doc, state, viewerSeat) → what to draw, with zero DOM.
@@ -105,10 +105,26 @@ function zoneTitle(zone: string, mine: boolean, ownerSeat: number | null, count:
   return `${who}${zone} (${count})`;
 }
 
+/** Local play: project + compute legal moves, then delegate to the projection core. */
 export function buildViewModel(doc: GameDocument, state: GameState, viewerSeat: number): ViewModel {
   const projected = projectState(state, doc.spec, viewerSeat);
   const yourTurn = state.status === "running" && state.activeSeat === viewerSeat;
   const moves = yourTurn ? legalMoves(state, doc.spec) : [];
+  return buildViewModelFromProjection(doc, projected, moves);
+}
+
+/**
+ * The projection core — also the ONLINE path: the server sends exactly a ProjectedState
+ * + this seat's legal moves (Hearthstone-style options), and this renders it. Clients
+ * never evaluate rules.
+ */
+export function buildViewModelFromProjection(
+  doc: GameDocument,
+  projected: ProjectedState,
+  moves: readonly PlayerMove[],
+): ViewModel {
+  const viewerSeat = projected.viewerSeat;
+  const yourTurn = projected.status === "running" && projected.activeSeat === viewerSeat;
   const moveByTarget = new Map<string, PlayerMove>();
   const buttons: MoveButtonVM[] = [];
   for (const move of moves) {
@@ -154,35 +170,36 @@ export function buildViewModel(doc: GameDocument, state: GameState, viewerSeat: 
     };
   });
 
-  const ended = state.status === "ended";
+  const ended = projected.status === "ended";
   const winnerText = !ended
     ? null
-    : state.winnerSeat === null
+    : projected.winnerSeat === null
       ? "It's a draw!"
-      : state.winnerSeat === viewerSeat
+      : projected.winnerSeat === viewerSeat
         ? "You win! 🏆"
-        : `Seat ${state.winnerSeat} wins.`;
+        : `Seat ${projected.winnerSeat} wins.`;
 
-  const phase = doc.spec.turn.phases[state.phaseIndex]?.name ?? "";
+  const phase = doc.spec.turn.phases[projected.phaseIndex]?.name ?? "";
   const statusLine = ended
     ? (winnerText ?? "Game over.")
     : yourTurn
-      ? `Round ${state.round} — your turn (${phase.replace(/-/g, " ")})`
-      : `Round ${state.round} — seat ${state.activeSeat} is thinking…`;
+      ? `Round ${projected.round} — your turn (${phase.replace(/-/g, " ")})`
+      : `Round ${projected.round} — seat ${projected.activeSeat} is thinking…`;
 
   const seatVarNames = Object.keys(doc.spec.variables.perSeat);
+  const seatCount = Object.values(projected.seatVars)[0]?.length ?? doc.spec.meta.seats.min;
   const seatStats: SeatStatsVM[] =
     seatVarNames.length === 0
       ? []
-      : Array.from({ length: state.seats }, (_, seat) => ({
+      : Array.from({ length: seatCount }, (_, seat) => ({
           seat,
           mine: seat === viewerSeat,
           title: seat === viewerSeat ? "you" : `seat ${seat}`,
-          stats: seatVarNames.map((name) => ({ name, value: state.seatVars[name]?.[seat] ?? 0 })),
+          stats: seatVarNames.map((name) => ({ name, value: projected.seatVars[name]?.[seat] ?? 0 })),
         }));
   const globalStats: StatVM[] = Object.keys(doc.spec.variables.global).map((name) => ({
     name,
-    value: state.vars[name] ?? 0,
+    value: projected.vars[name] ?? 0,
   }));
 
   return {

--- a/packages/runtime/src/domain/service/projection.ts
+++ b/packages/runtime/src/domain/service/projection.ts
@@ -50,6 +50,9 @@ export interface ProjectedState {
   readonly phaseIndex: number;
   readonly winnerSeat: number | null;
   readonly zones: readonly ProjectedZone[];
+  /** Variables are public in v1alpha (health/mana/score are open information). */
+  readonly vars: Readonly<Record<string, number>>;
+  readonly seatVars: Readonly<Record<string, readonly number[]>>;
 }
 
 /**
@@ -97,6 +100,8 @@ export function projectState(state: GameState, spec: GameSpec, viewerSeat: numbe
     phaseIndex: state.phaseIndex,
     winnerSeat: state.winnerSeat,
     zones,
+    vars: { ...state.vars },
+    seatVars: Object.fromEntries(Object.entries(state.seatVars).map(([k, v]) => [k, [...v]])),
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@junction/node':
+        specifier: workspace:*
+        version: link:../node
       '@junction/renderer':
         specifier: workspace:*
         version: link:../renderer
@@ -59,6 +62,28 @@ importers:
       zod:
         specifier: ^4.0.0
         version: 4.4.3
+
+  packages/node:
+    dependencies:
+      '@junction/connexon':
+        specifier: workspace:*
+        version: link:../connexon
+      '@junction/renderer':
+        specifier: workspace:*
+        version: link:../renderer
+      '@junction/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+      '@junction/spec':
+        specifier: workspace:*
+        version: link:../spec
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
+    devDependencies:
+      '@types/ws':
+        specifier: ^8.5.0
+        version: 8.18.1
 
   packages/renderer:
     dependencies:
@@ -566,6 +591,9 @@ packages:
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
@@ -1165,6 +1193,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -1457,6 +1497,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.21
 
   '@vitest/expect@3.2.6':
     dependencies:
@@ -2124,6 +2168,8 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   yaml@2.9.0: {}
 

--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -14,9 +14,11 @@ const RULES = {
   renderer: { allow: ["@junction/spec", "@junction/runtime"], allowNode: false, sideEffectsFree: true },
   // Connexon: the online runtime core. Platform-agnostic — no node, no @cloudflare; adapters live elsewhere.
   connexon: { allow: ["@junction/spec", "@junction/runtime"], allowNode: false, sideEffectsFree: true },
+  // Node adapter: Connexon's ws transport + local server. Node allowed by definition.
+  node: { allow: ["@junction/spec", "@junction/runtime", "@junction/connexon", "@junction/renderer"], allowNode: true, sideEffectsFree: false },
   // Integrin: the MCP server. Imports spec+runtime; the SDK + stdio transport need node.
   mcp: { allow: ["@junction/spec", "@junction/runtime", "@junction/renderer"], allowNode: true, sideEffectsFree: false },
-  cli: { allow: ["@junction/spec", "@junction/runtime", "@junction/renderer"], allowNode: true, sideEffectsFree: false },
+  cli: { allow: ["@junction/spec", "@junction/runtime", "@junction/renderer", "@junction/node"], allowNode: true, sideEffectsFree: false },
 };
 const FORBIDDEN_EVERYWHERE = [/@cloudflare\//, /\bworkerd\b/];
 


### PR DESCRIPTION
## Summary

Two browsers now play each other through an authoritative room with a join code — E3, locally complete:

- **HandleCodec**: piece ids are creation-ordered (decodable), so every id becomes an opaque handle from a server-secret shuffle before crossing the wire; stable per room so FLIP keys and targeting survive reconnects.
- **Server-sent options**: `welcome`/`patch` carry the seat's legal `moves` — clients never evaluate rules (the Hearthstone pattern). `ProjectedState` gains public `vars`/`seatVars` so variable games are legible online.
- **Online client**: `buildViewModelFromProjection` extracted as the view-model core; `mountOnlineGame` renders wire frames with the full juice (theme/sound/FLIP/stat pulses/confetti) and reconnects with token+lastSeq; classroom join screen for typing the projector code.
- **`@junction/node`** (new): the ws adapter + local host — `junction serve <game>` prints a join code + URL, serves the play page, `/ws?code=`, and `/check` (the school-IT self-test). The blueprint's portability hedge, now in CI.
- **Integration test**: two real WebSocket clients play War to completion — handle-translated hidden info verified on the wire, identical event stories both sides.
- Verified live in a browser: joined a served Math Duel room by code, struck for 8 over ws://, bot answered for 7, stats pulsing under the LIVE badge.

**101 tests across 7 packages**; `pnpm check` green.

*Process note: this commit briefly landed directly on main by mistake; main was restored and the work re-landed through this PR per house rule #7.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)